### PR TITLE
Create translation PR for files that change with commit.

### DIFF
--- a/.github/workflows/gpt-translate.yml
+++ b/.github/workflows/gpt-translate.yml
@@ -3,7 +3,7 @@ name: GPT Translate per Commit
 on:
   push:
     branches:
-      - master
+      - main
 jobs:
   gpt_translate:
     runs-on: ubuntu-latest

--- a/.github/workflows/gpt-translate.yml
+++ b/.github/workflows/gpt-translate.yml
@@ -1,40 +1,28 @@
-# .github/workflows/gpt-translate.yml
-
-name: GPT Translate
+name: GPT Translate per Commit
 
 on:
-  issue_comment:
-    type: [created]
-    
-  # Allows you to run this workflow manually from the Actions tab
-  workflow_dispatch:
-
+  push:
+    branches:
+      - master
 jobs:
   gpt_translate:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
-      
+      - name: Checkout repository with two latest commits
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 2
+
       - name: get changed files name
         id: changed_files
-        run: echo "name=files::$(git diff-tree --no-commit-id --name-only -r ${{ github.sha }})" >> $GITHUB_OUTPUT
+        run: |
+          echo "files=$(git diff --name-only HEAD^ HEAD | grep '\.md$' | tr '\n' ' ')" >> $GITHUB_OUTPUT
 
       - name: Run GPT Translate
-        uses: 3ru/gpt-translate@v1.0
+        uses: 3ru/gpt-translate@v1.1.1
         with:
           apikey: ${{ secrets.OPENAI_API_KEY }}
-          
-        if: |
-          contains(github.event.comment.body, '/gpt-translate') || 
-          contains(github.event.comment.body, '/gt')
-          
-          for changed_file in ${{ steps.changed_files.outputs.files }}
-          /gpt-translate $changed_file /DE/$changed_file German
-          /gpt-translate $changed_file /IT/$changed_file Italian
-          /gpt-translate $changed_file /FR/$changed_file French
-          
-        #  /gpt-translate [input filepath] [output filepath] [target language]
-
-
-
+          inputFiles: ${{ steps.changed_files.outputs.files }}
+          outputFiles: "./DE/*.md ./IT/*.md ./FR/*.md"
+          languages: "German Italian French"


### PR DESCRIPTION
A PR is created to translate the file when a commit is added to the main branch with changes to a markdown file.
If you find it annoying that a PR is created each time, disable this workflow.


Also, if you want to translate the entire `EN` directory, you can use the wildcard directory selection command.
```bash
/gpt-translate EN/*.md DE/*.md German
```
The command needs to be executed four times for four languages, but the burden will be reduced because it can be done all at once at the beginning.